### PR TITLE
Add a Dockerfile for gcsfuse

### DIFF
--- a/gcsfuse/Dockerfile
+++ b/gcsfuse/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:latest
+
+RUN apk add --update musl-dev go git fuse
+RUN mkdir /go
+RUN GOPATH=/go go get -u github.com/googlecloudplatform/gcsfuse
+
+ENTRYPOINT "/go/bin/gcsfuse"


### PR DESCRIPTION
This will be used to build a container we host for anyone wanting to run
gcsfuse inside pipelines.