### PR TITLE
Retry non-fatal errors

### DIFF
--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -189,7 +189,7 @@ func Invoke(ctx context.Context, service *genomics.Service, project string, argu
 		return nil
 	}
 
-	attempt:=uint(1)
+	attempt := uint(1)
 	for {
 		lro, err := service.Pipelines.Run(req).Context(ctx).Do()
 		if err != nil {
@@ -213,14 +213,14 @@ func Invoke(ctx context.Context, service *genomics.Service, project string, argu
 		if err := watch.Invoke(ctx, service, project, []string{lro.Name}); err != nil {
 			if e, ok := err.(common.PipelineExecutionError); ok && e.IsRetriable() {
 				// non-fatal error
-				if(attempt >= *attempts) {
+				if attempt >= *attempts {
 					fmt.Printf("Non fatal error occured. Reached maximum number of attempts\n")
 					return err
 				}
 				attempt++
-				fmt.Printf("Non fatal error occured: %v\n", e);
-				fmt.Printf("Retrying operation. Attempt: %d\n", attempt);
-				continue;
+				fmt.Printf("Non fatal error occured: %v\n", e)
+				fmt.Printf("Retrying operation. Attempt: %d\n", attempt)
+				continue
 			} else {
 				// fatal error
 				return err

--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -155,7 +155,7 @@ var (
 	cloudSDKImage  = flags.String("cloud-sdk-image", "google/cloud-sdk:alpine", "the cloud SDK image to use")
 	timeout        = flags.Duration("timeout", 0, "how long to wait before the operation is abandoned")
 	defaultImage   = flags.String("image", "bash", "the default image to use when executing commands")
-	attempts       = flag.Uint("attempts", 1, "number of attempts on non-fatal failure")
+	attempts       = flags.Uint("attempts", 1, "number of attempts on non-fatal failure")
 )
 
 func init() {
@@ -180,10 +180,6 @@ func Invoke(ctx context.Context, service *genomics.Service, project string, argu
 		return fmt.Errorf("encoding request: %v", err)
 	}
 	fmt.Printf("%s\n", encoded)
-
-	if *attempts == 0 {
-		return fmt.Errorf("attempts must be non-zero")
-	}
 
 	if *dryRun {
 		return nil

--- a/pipelines/internal/commands/watch/watch.go
+++ b/pipelines/internal/commands/watch/watch.go
@@ -46,7 +46,7 @@ func Invoke(ctx context.Context, service *genomics.Service, project string, argu
 	}
 
 	if status, ok := result.(*genomics.Status); ok {
-		return fmt.Errorf("executing pipeline: %s", status.Message)
+		return common.PipelineExecutionError(*status)
 	}
 
 	fmt.Println("Pipeline execution completed")

--- a/pipelines/internal/common/common.go
+++ b/pipelines/internal/common/common.go
@@ -59,24 +59,17 @@ func (m *MapFlagValue) Set(input string) error {
 // during a pipeline execution
 type PipelineExecutionError genomics.Status
 
-func (status PipelineExecutionError) Error() string {
-	return fmt.Sprintf("executing pipeline: %d : %s", status.Code, status.Message)
-}
-
-// Map that indicates which Genomics errors are fatal and
-// for which the user should retry the operation.
-// Errors that are not present or have the value "false" are fatal and
-// should not be retried.
-var retriableErrors map[string]bool = map[string]bool{
-	"UNAVAILABLE":         true,
-	"ABORTED":             true,
-	"FAILED_PRECONDITION": false,
-	"CANCELLED":           false,
-	"INVALID_ARGUMENT":    false,
+func (err PipelineExecutionError) Error() string {
+	return fmt.Sprintf("executing pipeline: %d : %s", err.Code, err.Message)
 }
 
 // IsRetriable indicates if the user should retry the operation after receiving
 // the current error.
-func (status PipelineExecutionError) IsRetriable() bool {
-	return retriableErrors[code.Code_name[int32(status.Code)]]
+func (err PipelineExecutionError) IsRetriable() bool {
+	switch code.Code_name[int32(err.Code)] {
+	case "UNAVAILABLE", "ABORTED":
+		return true
+	default:
+		return false
+	}
 }

--- a/pipelines/internal/common/common.go
+++ b/pipelines/internal/common/common.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/go-genproto/googleapis/rpc/code"
 	genomics "google.golang.org/api/genomics/v2alpha1"
-
 )
 
 // ExpandOperationName adds the project and operations prefixes to name (if
@@ -61,19 +60,19 @@ func (m *MapFlagValue) Set(input string) error {
 type PipelineExecutionError genomics.Status
 
 func (status PipelineExecutionError) Error() string {
-	return fmt.Sprintf( "executing pipeline: %d : %s", status.Code, status.Message)
+	return fmt.Sprintf("executing pipeline: %d : %s", status.Code, status.Message)
 }
 
 // Map that indicates which Genomics errors are fatal and
 // for which the user should retry the operation.
 // Errors that are not present or have the value "false" are fatal and
 // should not be retried.
-var retriableErrors map[string]bool= map[string]bool{
-	"UNAVAILABLE": true,
-	"ABORTED" : true,
-	"FAILED_PRECONDITION" : false,
-	"CANCELLED": false,
-	"INVALID_ARGUMENT" : false,
+var retriableErrors map[string]bool = map[string]bool{
+	"UNAVAILABLE":         true,
+	"ABORTED":             true,
+	"FAILED_PRECONDITION": false,
+	"CANCELLED":           false,
+	"INVALID_ARGUMENT":    false,
 }
 
 // IsRetriable indicates if the user should retry the operation after receiving


### PR DESCRIPTION
Added the --attempts flag to the run command so the user can specify how many attempts should be made running the provided pipeline when the returned error is non-fatal