### PR TITLE
Emit the operation ID when run fails

### DIFF
--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -229,7 +229,7 @@ func runPipeline(ctx context.Context, service *genomics.Service, req *genomics.R
 					continue
 				}
 			}
-			return err
+			return fmt.Errorf("operation %q failed: %v", lro.Name, err)
 		}
 		return nil
 	}


### PR DESCRIPTION
The ID is already logged higher up but it's nice to have it in the error
message when this tool is being invoked from scripts, etc.