### PR TITLE
Changed pipelines tool to use the published GCS fuse container

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,21 +67,11 @@ The script file format is described in the [source code for the command][3].
 
 ### Using gcsfuse with the pipelines tool
 
-The `pipelines` tool can use [gcsfuse][gcs-fuse] to localize input files
-instead of copying them one by one with `gsutil`.  There are a few important
-caveats when using the `--fuse` flag:
+Use `--fuse` flag to allow the `pipelines` tool to use [gcsfuse][gcs-fuse] to localize input files
+instead of copying them one by one with `gsutil`.
 
-1. You must build a gcsfuse docker container and push it into your project's
-Container Registry.  To do this, enter the `gcsfuse` subdirectory and run:
-
-```
-gcloud auth configure-docker
-docker build -t gcr.io/${GOOGLE_CLOUD_PROJECT}/gcsfuse .
-docker push gcr.io/${GOOGLE_CLOUD_PROJECT}/gcsfuse
-```
-
-2. Files other than those directly mentioned by the `--inputs` flag will be
-available to containers, since the entire bucket is mounted.
+Files other than those directly mentioned by the `--inputs` flag will be
+available to container, since the entire bucket is mounted.
 
 ### SSH into the worker machine
 

--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -303,7 +303,7 @@ func buildRequest(filename, project string) (*genomics.RunPipelineRequest, error
 		for _, path := range buckets {
 			directories = append(directories, path)
 		}
-		localizers = append(localizers, gcsFuse(project, buckets)...)
+		localizers = append(localizers, gcsFuse(buckets)...)
 	}
 
 	var delocalizers []*genomics.Action
@@ -727,17 +727,17 @@ func gcsTransfer(remote string) func(from, to string) *genomics.Action {
 	}
 }
 
-func gcsFuse(project string, buckets map[string]string) []*genomics.Action {
+func gcsFuse(buckets map[string]string) []*genomics.Action {
 	var actions []*genomics.Action
 	for bucket, path := range buckets {
 		actions = append(actions, &genomics.Action{
-			ImageUri: fmt.Sprintf("gcr.io/%s/gcsfuse", project),
+			ImageUri: fmt.Sprintf("gcr.io/cloud-genomics-pipelines/gcsfuse"),
 			Commands: []string{"--implicit-dirs", "--foreground", bucket, path},
 			Flags:    []string{"ENABLE_FUSE", "RUN_IN_BACKGROUND"},
 			Mounts:   []*genomics.Mount{googleRoot},
 		})
 		actions = append(actions, &genomics.Action{
-			ImageUri: fmt.Sprintf("gcr.io/%s/gcsfuse", project),
+			ImageUri: fmt.Sprintf("gcr.io/cloud-genomics-pipelines/gcsfuse"),
 			Commands: []string{"wait", path},
 			Mounts:   []*genomics.Mount{googleRoot},
 		})


### PR DESCRIPTION
Changed pipelines tool to use the published GCS fuse container instead  of requiring a user provided image. Updated the README to reflect those changes.