### PR TITLE
Add an exponential back off when watching pipelines

### DIFF
--- a/pipelines/internal/commands/watch/watch.go
+++ b/pipelines/internal/commands/watch/watch.go
@@ -55,8 +55,8 @@ func Invoke(ctx context.Context, service *genomics.Service, project string, argu
 
 func watch(ctx context.Context, service *genomics.Service, name string) (interface{}, error) {
 	var events []*genomics.Event
-	const minDelay = 5 * time.Second
-	var delay = minDelay
+	const initialDelay = 5 * time.Second
+	var delay = initialDelay
 	for {
 		lro, err := service.Projects.Operations.Get(name).Context(ctx).Do()
 		if err != nil {
@@ -78,7 +78,7 @@ func watch(ctx context.Context, service *genomics.Service, name string) (interfa
 				}
 			}
 			events = metadata.Events
-			delay = minDelay
+			delay = initialDelay
 		}
 
 		if lro.Done {

--- a/pipelines/internal/commands/watch/watch.go
+++ b/pipelines/internal/commands/watch/watch.go
@@ -56,7 +56,7 @@ func Invoke(ctx context.Context, service *genomics.Service, project string, argu
 func watch(ctx context.Context, service *genomics.Service, name string) (interface{}, error) {
 	var events []*genomics.Event
 	const initialDelay = 5 * time.Second
-	var delay = initialDelay
+	delay := initialDelay
 	for {
 		lro, err := service.Projects.Operations.Get(name).Context(ctx).Do()
 		if err != nil {


### PR DESCRIPTION
Initial back off timer is 5 seconds, back off factor is 1.5 - up to 1 minute delay. 
Each event resets the back off timer to 5 seconds. 