### PR TITLE
Added support for writing logs into GCS during runs. 

### DIFF
--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -329,7 +329,7 @@ func buildRequest(filename, project string) (*genomics.RunPipelineRequest, error
 
 	var actions []*genomics.Action
 	if *outputInterval != 0 && *output != "" {
-		action := bash(fmt.Sprintf("while true; do gsutil -q cp /google/logs/output %s; sleep %.0f; done", *output, (*outputInterval).Seconds()))
+		action := bash(fmt.Sprintf("while true; sleep %.0f; do gsutil -q cp /google/logs/output %s; done", (*outputInterval).Seconds(), *output))
 		action.Flags = []string{"RUN_IN_BACKGROUND"}
 		actions = append(actions, action)
 	}

--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -329,7 +329,7 @@ func buildRequest(filename, project string) (*genomics.RunPipelineRequest, error
 
 	var actions []*genomics.Action
 	if *outputInterval != 0 && *output != "" {
-		action := bash(fmt.Sprintf("while true; sleep %.0f; do gsutil -q cp /google/logs/output %s; done", (*outputInterval).Seconds(), *output))
+		action := bash(fmt.Sprintf("while true; do sleep %.0f; gsutil -q cp /google/logs/output %s; done", (*outputInterval).Seconds(), *output))
 		action.Flags = []string{"RUN_IN_BACKGROUND"}
 		actions = append(actions, action)
 	}

--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -171,7 +171,7 @@ var (
 	sharePIDs      = flags.Bool("share-pids", false, "if true, all actions will share the same PID namespace")
 	cosChannel     = flags.String("cos-channel", "", "if set, specifies the COS release channel to use")
 	serviceAccount = flags.String("service-account", "", "if set, specifies the service account for the VM")
-	logsInterval   = flags.Duration("logsInterval", 0, "if non-zero, specifies the time interval for logging output during runs")
+	outputInterval = flags.Duration("output-interval", 0, "if non-zero, specifies the time interval for logging output during runs")
 )
 
 func init() {
@@ -325,20 +325,22 @@ func buildRequest(filename, project string) (*genomics.RunPipelineRequest, error
 		action := gsutil("cp", "/google/logs/output", *output)
 		action.Flags = []string{"ALWAYS_RUN"}
 		delocalizers = append(delocalizers, action)
-		if *logsInterval != 0 {
-			action := periodicLogs("while true", fmt.Sprintf("do gsutil -q cp /google/logs/output %s", *output), fmt.Sprintf("sleep %.0f", (*logsInterval).Seconds()), "done")
-			localizers = append(localizers, action)
-		}
 	}
 
 	var actions []*genomics.Action
+	if *outputInterval != 0 && *output != "" {
+		action := bash(fmt.Sprintf("while true; do gsutil -q cp /google/logs/output %s; sleep %.0f; done", *output, (*outputInterval).Seconds()))
+		action.Flags = []string{"RUN_IN_BACKGROUND"}
+		actions = append(actions, action)
+	}
+
 	if filename != "" {
 		if err := parseJSON(filename, &actions); err != nil {
 			v, err := parseScript(filename)
 			if err != nil {
 				return nil, fmt.Errorf("creating pipeline from script: %v", err)
 			}
-			actions = v
+			actions = append(actions, v...)
 		}
 	} else if *command != "" {
 		action, err := parse(*command)
@@ -760,15 +762,5 @@ func sshDebug(project string) *genomics.Action {
 		Entrypoint:   "ssh-server",
 		PortMappings: map[string]int64{"22": 22},
 		Flags:        []string{"RUN_IN_BACKGROUND"},
-	}
-}
-
-func periodicLogs(arguments ...string) *genomics.Action {
-	return &genomics.Action{
-		ImageUri:   *cloudSDKImage,
-		Commands:   []string{"-c", strings.Join(arguments, "; ")},
-		Mounts:     []*genomics.Mount{googleRoot},
-		Entrypoint: "bash",
-		Flags:      []string{"RUN_IN_BACKGROUND"},
 	}
 }


### PR DESCRIPTION
The flag logsInterval, if not zero, specifies the interval between logs writes. The --output path must be specified.