### PR TITLE
Finish migration of io/Dockerfile to sdk:slim

### DIFF
--- a/io/Dockerfile
+++ b/io/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM google/cloud-sdk:slim
 
-RUN apk --no-cache add go musl-dev
+RUN apt-get install -y golang
 
 COPY retry/retry.go .
 RUN go build -o /usr/local/bin/retry retry.go

--- a/io/wrappers/gsutil
+++ b/io/wrappers/gsutil
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-retry /google-cloud-sdk/bin/gsutil $@
+retry /usr/lib/google-cloud-sdk/bin/gsutil $@


### PR DESCRIPTION
The image name was modified in a previous commit but it was apparently not
tested.  This change corrects the installation tool used and the cloud-sdk
paths for :slim vs :alpine.