### PR TITLE
Default to using the pipelines-io container for IO

### DIFF
--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -156,7 +156,7 @@ var (
 	diskImage      = flags.String("disk-image", "", "optional image to pre-load onto the attached disk")
 	bootDiskSizeGb = flags.Int("boot-disk-size", 0, "if non-zero, specifies the boot disk size (in GB)")
 	privateAddress = flags.Bool("private-address", false, "use a private IP address")
-	cloudSDKImage  = flags.String("cloud-sdk-image", "google/cloud-sdk:slim", "the cloud SDK image to use")
+	cloudSDKImage  = flags.String("cloud-sdk-image", "gcr.io/cloud-genomics-pipelines/io", "the cloud SDK image to use")
 	timeout        = flags.Duration("timeout", 0, "how long to wait before the operation is abandoned")
 	defaultImage   = flags.String("image", "bash", "the default image to use when executing commands")
 	attempts       = flags.Uint("attempts", 0, "number of attempts on non-fatal failure, using non-preemptible VM")


### PR DESCRIPTION
This container is based on the cloud-sdk image but provides nice retry
behaviour for known bugs in the cloud SDK, so using it by default is a good
choice.

The cloud-sdk-image flag should probably be renamed to 'io-container' or
something.  I may do that in a follow up CL.