### PR TITLE
Escape arguments to gsutil

### DIFF
--- a/io/wrappers/gsutil
+++ b/io/wrappers/gsutil
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-retry /usr/lib/google-cloud-sdk/bin/gsutil $@
+retry /usr/lib/google-cloud-sdk/bin/gsutil "$@"


### PR DESCRIPTION
Using a bare expansion of $@ prevents multi-word quoted arguments from working
properly.