### PR TITLE
Build the docker containers using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: go
 go:
   - "1.10.x"
+
+services:
+  - docker
+
+script:
+  - go test ./...
+  - docker build .
+  - docker build io/
+  - docker build gcsfuse/


### PR DESCRIPTION
Without this, we don't catch problems until the cloud builder runs.