### PR TITLE
Modify pipelines tool to accept regions along side zones.

### DIFF
--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -394,16 +394,17 @@ func buildRequest(filename, project string) (*genomics.RunPipelineRequest, error
 			return nil, fmt.Errorf("expanding regions: %v", err)
 		}
 		resources.Regions = regions
-	} else {
-		if *zones == "" {
-			*zones = "us-east1-d"
-		}
+    }
+    if *zones != "" {
 		zones, err := expandPrefixes(project, listOf(*zones), listZones)
 		if err != nil {
 			return nil, fmt.Errorf("expanding zones: %v", err)
 		}
 		resources.Zones = zones
-	}
+    }
+    if len(resources.Zones) + len(resources.Regions) == 0 {
+        resources.Zones = []string{"us-east1-d"}
+    }
 
 	pipeline := &genomics.Pipeline{
 		Resources:   resources,

--- a/pipelines/internal/commands/run/run.go
+++ b/pipelines/internal/commands/run/run.go
@@ -152,6 +152,7 @@ var (
 	name           = flags.String("name", "", "optional name applied as a label")
 	scopes         = flags.String("scopes", "", "comma separated list of additional API scopes")
 	zones          = flags.String("zones", "", "comma separated list of zone names or prefixes (e.g. us-*)")
+	regions        = flags.String("regions", "", "comma separated list of region names or prefixes (e.g. us-*)")
 	output         = flags.String("output", "", "GCS path to write output to")
 	dryRun         = flags.Bool("dry-run", false, "don't run, just show pipeline")
 	wait           = flags.Bool("wait", true, "wait for the pipeline to finish")
@@ -179,7 +180,6 @@ var (
 	cosChannel     = flags.String("cos-channel", "", "if set, specifies the COS release channel to use")
 	serviceAccount = flags.String("service-account", "", "if set, specifies the service account for the VM")
 	outputInterval = flags.Duration("output-interval", 0, "if non-zero, specifies the time interval for logging output during runs")
-	regions        = flags.String("regions", "", "comma separated list of region names or prefixes (e.g. us-*)")
 )
 
 func init() {


### PR DESCRIPTION
Since this tool is pretty much exclusively used by Genomics team, opted to remove the default for zone and to demand either zone or region.

Another approach would had been to keep defaulting zone, but use region first, if supplied. Although this would provide backwards compatibility, this could lead to potentially unexpected results for callers when zone and regions are simultaneously supplied.